### PR TITLE
Clear rtRemoteObjectCache on client shutdown to prevent related crashes

### DIFF
--- a/include/rtRemoteObjectCache.h
+++ b/include/rtRemoteObjectCache.h
@@ -42,7 +42,7 @@ public:
   rtError touch(std::string const& id, std::chrono::steady_clock::time_point now);
   rtError erase(std::string const& id);
   rtError markUnevictable(std::string const& id, bool state);
-  rtError removeUnused();
+  rtError removeUnused(bool expireAll = false);
   rtError clear();
 
 private:

--- a/src/rtRemoteObjectCache.cpp
+++ b/src/rtRemoteObjectCache.cpp
@@ -197,7 +197,7 @@ rtRemoteObjectCache::erase(std::string const& id)
 }
 
 rtError
-rtRemoteObjectCache::removeUnused()
+rtRemoteObjectCache::removeUnused(bool expireAll)
 {
   auto now = std::chrono::steady_clock::now();
 
@@ -215,7 +215,7 @@ rtRemoteObjectCache::removeUnused()
     }
     #endif
 
-    if (!itr->second.Unevictable && !itr->second.isActive(now))
+    if (!itr->second.Unevictable && (expireAll || !itr->second.isActive(now)))
       itr = sRefMap.erase(itr);
     else
       ++itr;

--- a/src/rtRemoteServer.cpp
+++ b/src/rtRemoteServer.cpp
@@ -443,6 +443,7 @@ rtRemoteServer::onClientStateChanged(std::shared_ptr<rtRemoteClient> const& clie
     }
   }
 
+  m_env->ObjectCache->removeUnused(true);
   return e;
 }
 

--- a/src/rtRemoteStreamSelector.cpp
+++ b/src/rtRemoteStreamSelector.cpp
@@ -71,7 +71,7 @@ rtRemoteStreamSelector::registerStream(std::shared_ptr<rtRemoteStream> const& s)
 rtError
 rtRemoteStreamSelector::shutdown()
 {
-  char buff[] = { "shudown" };
+  char buff[] = { "shutdown" };
 
   {
     std::unique_lock<std::mutex> lock(m_mutex);


### PR DESCRIPTION
 At the time of shutdown any client, it is necessary to remove its objects from the ObjectCache on the server side to prevent subsequent crashes when trying to access non-existing objects.

Additionally, this commit corrects a typo in the signal name, although this does not affect the functionality at this time.