### PR TITLE
Revert "Clear rtRemoteObjectCache on rtRemoteClient shutdown to preve…

### DIFF
--- a/include/rtRemoteObjectCache.h
+++ b/include/rtRemoteObjectCache.h
@@ -42,7 +42,7 @@ public:
   rtError touch(std::string const& id, std::chrono::steady_clock::time_point now);
   rtError erase(std::string const& id);
   rtError markUnevictable(std::string const& id, bool state);
-  rtError removeUnused(bool expireAll = false);
+  rtError removeUnused();
   rtError clear();
 
 private:

--- a/src/rtRemoteObjectCache.cpp
+++ b/src/rtRemoteObjectCache.cpp
@@ -197,7 +197,7 @@ rtRemoteObjectCache::erase(std::string const& id)
 }
 
 rtError
-rtRemoteObjectCache::removeUnused(bool expireAll)
+rtRemoteObjectCache::removeUnused()
 {
   auto now = std::chrono::steady_clock::now();
 
@@ -215,7 +215,7 @@ rtRemoteObjectCache::removeUnused(bool expireAll)
     }
     #endif
 
-    if (!itr->second.Unevictable && (expireAll || !itr->second.isActive(now)))
+    if (!itr->second.Unevictable && !itr->second.isActive(now))
       itr = sRefMap.erase(itr);
     else
       ++itr;

--- a/src/rtRemoteServer.cpp
+++ b/src/rtRemoteServer.cpp
@@ -443,7 +443,6 @@ rtRemoteServer::onClientStateChanged(std::shared_ptr<rtRemoteClient> const& clie
     }
   }
 
-  m_env->ObjectCache->removeUnused(true);
   return e;
 }
 

--- a/src/rtRemoteStreamSelector.cpp
+++ b/src/rtRemoteStreamSelector.cpp
@@ -71,7 +71,7 @@ rtRemoteStreamSelector::registerStream(std::shared_ptr<rtRemoteStream> const& s)
 rtError
 rtRemoteStreamSelector::shutdown()
 {
-  char buff[] = { "shutdown" };
+  char buff[] = { "shudown" };
 
   {
     std::unique_lock<std::mutex> lock(m_mutex);


### PR DESCRIPTION
…nt related crashes"

This reverts commit e13e9554c06d3285402f892a7549504e456b3d0b.

We shouldn't clear the entire object cache when a single client disconnects.  This was originally meant to fix crashes during rtRemoteShutdown (XRE-13675).  However this creates a bigger problem by breaking other connected clients such as rdkbrowser (XRE-13866).  After reverting I am unable to reproduce the original crashes with either rtSamples or Receiver so I maybe those crash conditions no longer exist.    
