### PR TITLE
Fix a crash during rtRemoteServer shutdown

### DIFF
--- a/include/rtRemoteObjectCache.h
+++ b/include/rtRemoteObjectCache.h
@@ -42,7 +42,7 @@ public:
   rtError touch(std::string const& id, std::chrono::steady_clock::time_point now);
   rtError erase(std::string const& id);
   rtError markUnevictable(std::string const& id, bool state);
-  rtError removeUnused();
+  rtError removeUnused(bool expireAll = false);
   rtError clear();
 
 private:

--- a/src/rtRemoteObjectCache.cpp
+++ b/src/rtRemoteObjectCache.cpp
@@ -197,7 +197,7 @@ rtRemoteObjectCache::erase(std::string const& id)
 }
 
 rtError
-rtRemoteObjectCache::removeUnused()
+rtRemoteObjectCache::removeUnused(bool expireAll)
 {
   auto now = std::chrono::steady_clock::now();
 
@@ -208,7 +208,7 @@ rtRemoteObjectCache::removeUnused()
     //           std::chrono::duration_cast<std::chrono::seconds>(now - itr->second.LastUsed).count(),
     //           itr->second.MaxIdleTime.count(), itr->second.Unevictable);
     #if 0
-    if (!itr->second.Unevictable && itr->second.isActive(now))
+    if (!itr->second.Unevictable && (expireAll || itr->second.isActive(now)))
     {
       rtLogInfo("not removing:%s, should remove, but it's active",
         itr->first.c_str());

--- a/src/rtRemoteServer.cpp
+++ b/src/rtRemoteServer.cpp
@@ -443,6 +443,8 @@ rtRemoteServer::onClientStateChanged(std::shared_ptr<rtRemoteClient> const& clie
     }
   }
 
+  m_env->ObjectCache->removeUnused(true);
+
   return e;
 }
 

--- a/src/rtRemoteStreamSelector.cpp
+++ b/src/rtRemoteStreamSelector.cpp
@@ -71,7 +71,7 @@ rtRemoteStreamSelector::registerStream(std::shared_ptr<rtRemoteStream> const& s)
 rtError
 rtRemoteStreamSelector::shutdown()
 {
-  char buff[] = { "shudown" };
+  char buff[] = { "shutdown" };
 
   {
     std::unique_lock<std::mutex> lock(m_mutex);


### PR DESCRIPTION
- Remove all invalid objects from rtObjectCache on any client shutdown
  (to prevent a crash on server shutdown)
- Fix a typo ("shudown" -> "shutdown")
