### PR TITLE
RDK-30422: Configure socket path

### DIFF
--- a/include/rtRemoteEnvironment.h
+++ b/include/rtRemoteEnvironment.h
@@ -22,6 +22,7 @@ limitations under the License.
 #include "rtRemoteCallback.h"
 #include "rtRemoteCorrelationKey.h"
 #include "rtRemoteMessageHandler.h"
+#include "rtRemoteConfig.h"
 
 #include <condition_variable>
 #include <map>
@@ -30,7 +31,6 @@ limitations under the License.
 #include <thread>
 
 class rtRemoteServer;
-class rtRemoteConfig;
 class rtRemoteStreamSelector;
 class rtRemoteObjectCache;
 

--- a/include/rtRemoteSocketUtils.h
+++ b/include/rtRemoteSocketUtils.h
@@ -37,7 +37,6 @@ limitations under the License.
 #endif
 
 #define kInvalidSocket (-1)
-#define kUnixSocketTemplateRoot "/tmp/rt_remote_soc"
 
 rtError rtParseAddress(sockaddr_storage& ss, char const* addr, uint16_t port, uint32_t* index);
 rtError rtParseAddress(sockaddr_storage& ss, char const* s);

--- a/include/rtRemoteSocketUtils.h
+++ b/include/rtRemoteSocketUtils.h
@@ -28,6 +28,7 @@ limitations under the License.
 #include <string>
 #include <vector>
 
+#include "rtRemoteEnvironment.h"
 #include "rtRemoteSocketBuffer.h"
 #include "rtRemoteMessage.h"
 
@@ -56,6 +57,6 @@ rtError rtGetPeerName(int fd, sockaddr_storage& endpoint);
 rtError rtGetSockName(int fd, sockaddr_storage& endpoint);
 rtError	rtCloseSocket(int& fd);
 rtError rtGetDefaultInterface(sockaddr_storage& addr, uint16_t port);
-rtError rtCreateUnixSocketName(pid_t pid, char* buff, int n);
+rtError rtCreateUnixSocketName(rtRemoteEnvironment* env, pid_t pid, char* buff, int n);
 
 #endif

--- a/rtremote.conf.ac
+++ b/rtremote.conf.ac
@@ -16,6 +16,10 @@
     "default_value":"unix",
     "type":"string" },
 
+{ "name":"rt.rpc.server.unix_socket_template",
+    "default_value":"/tmp/rt_remote_soc",
+    "type":"string" },
+
 { "name":"rt.rpc.server.use_dispatch_thread",
     "default_value":"false",
     "type":"bool" },
@@ -29,10 +33,6 @@
     "default_value":"lo",
     "type":"string",
     "platform":"linux" },
-
-{ "name":"rt.rpc.server.socket_family",
-    "default_value":"inet",
-    "type":"string" },
 
 { "name":"rt.rpc.resolver.multicast.interface",
     "default_value":"en0",

--- a/src/rtRemoteServer.cpp
+++ b/src/rtRemoteServer.cpp
@@ -131,6 +131,7 @@ namespace
       {
         memset(path, 0, sizeof(path));
         strcpy(path, socketDir.c_str());
+        strcat(path, "/");
         strcat(path, result->d_name);
         if (strncmp(path, socketTemplate.c_str(), strlen(socketTemplate.c_str())) == 0)
         {

--- a/src/rtRemoteSocketUtils.cpp
+++ b/src/rtRemoteSocketUtils.cpp
@@ -556,7 +556,7 @@ rtGetDefaultInterface(sockaddr_storage& addr, uint16_t port)
 }
 
 rtError
-rtCreateUnixSocketName(pid_t pid, char* buff, int n)
+rtCreateUnixSocketName(rtRemoteEnvironment* env, pid_t pid, char* buff, int n)
 {
   if (!buff)
     return RT_ERROR_INVALID_ARG;
@@ -564,7 +564,9 @@ rtCreateUnixSocketName(pid_t pid, char* buff, int n)
   if (pid == 0)
     pid = getpid();
 
-  int count = snprintf(buff, n, "%s.%d", kUnixSocketTemplateRoot, pid);
+  std::string socketPath = env->Config->server_unix_socket_template();
+
+  int count = snprintf(buff, n, "%s.%d", socketPath.c_str(), pid);
   if (count >= n)
   {
     rtLogError("truncated socket path %d <= %d", n, count);


### PR DESCRIPTION
Create a new config option to allow defining a custom socket path instead of `/tmp/rt_remote_soc`. Defaults to `/tmp/rt_remote_soc` if config option is not present to not break existing builds.

Directory must exist before starting rtRemote otherwise it will fail to start.

Add hostname to socket to prevent duplicates when using containers