### PR TITLE
rtRemoteEnvironment log flooding causing log rotation issue

### DIFF
--- a/src/rtRemoteEnvironment.cpp
+++ b/src/rtRemoteEnvironment.cpp
@@ -210,7 +210,12 @@ rtRemoteEnvironment::processSingleWorkItem(std::chrono::milliseconds timeout, bo
   {
     if (!m_running)
     {
-      rtLogError("processSingleWorkItem: env is not running. RT_FAIL");
+      static bool logged = false;
+      if (!logged)
+      {
+        logged = true;
+        rtLogError("processSingleWorkItem: env is not running. RT_FAIL");
+      }
       return RT_FAIL;
     }
 


### PR DESCRIPTION
Reason for change: Huge number of identical log messages is being printed
