### PR TITLE
RDKDEV-651 cleanup disconnected client

### DIFF
--- a/src/rtRemoteServer.cpp
+++ b/src/rtRemoteServer.cpp
@@ -441,6 +441,15 @@ rtRemoteServer::onClientStateChanged(std::shared_ptr<rtRemoteClient> const& clie
         ditr->second.clear();
         m_disconnected_callback_map.erase(ditr);
     }
+
+    // also remove the disconnected client from m_object_map
+    for (auto itr = m_object_map.begin(); itr != m_object_map.end();)
+    {
+      if (itr->second.get() == client.get())
+        itr = m_object_map.erase(itr);
+      else
+        ++itr;
+    }
   }
 
   return e;


### PR DESCRIPTION
After socket shutdown, the client was still being kept in rtRemoteServer m_object_map, and subsequent findObject searches were trying to reuse this disconnected client instance.